### PR TITLE
SERVER_PORT is not always a int

### DIFF
--- a/src/Http.php
+++ b/src/Http.php
@@ -69,6 +69,8 @@ class Http extends AbstractUri implements UriInterface
         list($host, $port) = static::fetchHostname($server);
         list($path, $query) = static::fetchRequestUri($server);
 
+        $port = $port !== null ? (int) $port : $port;
+
         return new static(static::fetchScheme($server), $user, $pass, $host, $port, $path, $query);
     }
 
@@ -133,7 +135,7 @@ class Http extends AbstractUri implements UriInterface
 
             return [
                 $matches['host'],
-                isset($matches['port']) ? (int) $matches['port'] : (int) $server['SERVER_PORT'],
+                isset($matches['port']) ? (int) $matches['port'] : $server['SERVER_PORT'],
             ];
         }
 
@@ -145,7 +147,7 @@ class Http extends AbstractUri implements UriInterface
             $server['SERVER_ADDR'] = '['.$server['SERVER_ADDR'].']';
         }
 
-        return [$server['SERVER_ADDR'], (int) $server['SERVER_PORT']];
+        return [$server['SERVER_ADDR'], $server['SERVER_PORT']];
     }
 
     /**

--- a/src/Http.php
+++ b/src/Http.php
@@ -133,7 +133,7 @@ class Http extends AbstractUri implements UriInterface
 
             return [
                 $matches['host'],
-                isset($matches['port']) ? (int) $matches['port'] : $server['SERVER_PORT'],
+                isset($matches['port']) ? (int) $matches['port'] : (int) $server['SERVER_PORT'],
             ];
         }
 
@@ -145,7 +145,7 @@ class Http extends AbstractUri implements UriInterface
             $server['SERVER_ADDR'] = '['.$server['SERVER_ADDR'].']';
         }
 
-        return [$server['SERVER_ADDR'], $server['SERVER_PORT']];
+        return [$server['SERVER_ADDR'], (int) $server['SERVER_PORT']];
     }
 
     /**


### PR DESCRIPTION
## Introduction

SERVER_PORT is in most cases a string 

## Proposal

### Describe the new/upated/fixed feature

change SERVER_PORT always to a int

### Backward Incompatible Changes

-

### Targeted release version

_(Indicate the release version targeted for your PR)_

1.0.3