### PR TITLE
Optimize formatHost for ASCII-only domains

### DIFF
--- a/benchmark/parse.php
+++ b/benchmark/parse.php
@@ -1,0 +1,7 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+for ($i = 0; $i < 100000; $i++) {
+    League\Uri\Http::createFromString('http://amphp.org/amp');
+}

--- a/src/AbstractUri.php
+++ b/src/AbstractUri.php
@@ -297,7 +297,7 @@ abstract class AbstractUri implements UriInterface
      */
     protected function formatScheme(string $scheme = null)
     {
-        if (in_array($scheme, ['', null], true)) {
+        if ($scheme === '' || $scheme === null) {
             return $scheme;
         }
 
@@ -364,8 +364,14 @@ abstract class AbstractUri implements UriInterface
      */
     protected function formatHost($host)
     {
+        static $pattern = '/^(?<name>[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)(?:\.(?&name))*$/i';
+
         if ('' == $host || false !== strpos($host, ']')) {
             return $host;
+        }
+
+        if (!isset($host[253]) && preg_match($pattern, $host)) {
+            return strtolower($host);
         }
 
         $component = '';


### PR DESCRIPTION
## Introduction

ASCII-only domains are way more common than IDNs. With a similar change in the parser check, this gives a 35% CPU time reduction in the included benchmark according to Blackfire.

### Backward Incompatible Changes

None.

### Targeted release version

Next patch release.

### PR Impact

None.

## Open issues

I'm not sure why `idn_to_ascii` and the decoding are applied per label instead of directly to the host name, could anyone shed some light here? Also, the `mb_strtolower` is probably unnecessary and can be replaced with `strtolower`.

The `(string)` cast for `idn_to_ascii` seems strange, that will just empty all invalid labels and then contain two consecutive dots in the host?