### PR TITLE
Bug fix Factory::create method

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -121,13 +121,25 @@ class Factory
             return $this->resolve($this->newInstance($components, $className), $base_uri);
         }
 
-        if (null !== $components['scheme']) {
-            $className = $this->getClassName($components['scheme']);
-
-            return $this->newInstance($components, $className);
+        if (null == $components['scheme']) {
+            throw new Exception(sprintf('the submitted URI `%s` must be an absolute URI', $uri));
         }
 
-        throw new Exception(sprintf('the submitted URI `%s` must be an absolute URI', $uri));
+        $className = $this->getClassName($components['scheme']);
+        $uri = $this->newInstance($components, $className);
+        if ('' === $uri->getAuthority()) {
+            return $uri;
+        }
+
+        $path = $uri->getPath();
+        //@codeCoverageIgnoreStart
+        //because some PSR-7 Uri implementations allow this RFC3986 forbidden construction
+        if (0 !== strpos($path, '/')) {
+            $path = '/'.$path;
+        }
+        //@codeCoverageIgnoreEnd
+
+        return $uri->withPath($this->removeDotSegments($path));
     }
 
     /**

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -197,6 +197,12 @@ class FactoryTest extends TestCase
                 'uri' => 'https://example.com/path/to/file',
                 'base_uri' => Uri\Ftp::createFromString('ftp://example.com/index.php'),
             ],
+            'remove dot segments on URI without base URI' => [
+                'expected_class' => Uri\Http::class,
+                'expected_uri' => 'https://example.com/x',
+                'uri' => 'https://EXAMPLE.com/../x',
+                'base_uri' => null,
+            ],
         ];
     }
 


### PR DESCRIPTION
`Factory::create` only removes dot segment when a base URI is present.
This patch will make the method removing dot segment everytime it can and normalized the method output. 