### PR TITLE
Add missing non leading digit parsing for schemes, fixes #13

### DIFF
--- a/src/AbstractUri.php
+++ b/src/AbstractUri.php
@@ -225,13 +225,6 @@ abstract class AbstractUri implements UriInterface, DeprecatedLeagueUriInterface
     /**
      * Create a new instance.
      *
-     * @param null|string $scheme
-     * @param null|string $user
-     * @param null|string $pass
-     * @param null|string $host
-     * @param null|int    $port
-     * @param null|string $query
-     * @param null|string $fragment
      */
     protected function __construct(
         string $scheme = null,
@@ -257,7 +250,6 @@ abstract class AbstractUri implements UriInterface, DeprecatedLeagueUriInterface
     /**
      * Format the Scheme and Host component.
      *
-     * @param null|string $scheme
      *
      * @return string|null
      */
@@ -279,8 +271,6 @@ abstract class AbstractUri implements UriInterface, DeprecatedLeagueUriInterface
     /**
      * Set the UserInfo component.
      *
-     * @param  null|string $user
-     * @param  null|string $password
      * @return string|null
      */
     protected static function formatUserInfo(string $user = null, string $password = null)
@@ -617,10 +607,6 @@ abstract class AbstractUri implements UriInterface, DeprecatedLeagueUriInterface
      * Generate the URI string representation from its components.
      *
      * @see https://tools.ietf.org/html/rfc3986#section-5.3
-     * @param null|string $scheme
-     * @param null|string $authority
-     * @param null|string $query
-     * @param null|string $fragment
      */
     protected function getUriString(
         string $scheme = null,

--- a/src/AbstractUri.php
+++ b/src/AbstractUri.php
@@ -268,7 +268,7 @@ abstract class AbstractUri implements UriInterface, DeprecatedLeagueUriInterface
         }
 
         $formatted_scheme = strtolower($scheme);
-        static $pattern = '/^[a-z][a-z\+\.\-]*$/';
+        static $pattern = '/^[a-z][a-z0-9\+\.\-]*$/';
         if (preg_match($pattern, $formatted_scheme)) {
             return $formatted_scheme;
         }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -164,9 +164,7 @@ class Factory
      */
     protected function filterBaseUri($uri)
     {
-        if (!$uri instanceof Psr7UriInterface
-            && !$uri instanceof UriInterface
-            && !$uri instanceof DeprecatedLeagueUriInterface) {
+        if (!$uri instanceof Psr7UriInterface && !$uri instanceof UriInterface) {
             return $this->create($uri);
         }
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -78,6 +78,28 @@ class UriTest extends TestCase
     }
 
     /**
+     * @covers ::__toString
+     * @covers ::formatScheme
+     */
+    public function testConstructingUrisWithSchemesWithNonLeadingDigits()
+    {
+        $uri = 's3://somebucket/somefile.txt';
+        self::assertSame($uri, (string) Uri::createFromString($uri));
+    }
+
+    /**
+     * @covers ::__toString
+     * @covers ::formatScheme
+     * @covers ::withScheme
+     */
+    public function testSettingSchemesWithNonLeadingDigits()
+    {
+        $uri = 'http://somebucket/somefile.txt';
+        $expected_uri = 's3://somebucket/somefile.txt';
+        self::assertSame($expected_uri, (string) Uri::createFromString($uri)->withScheme('s3'));
+    }
+
+    /**
      * @covers ::getUriString
      * @covers ::__toString
      * @covers ::formatUserInfo


### PR DESCRIPTION
## Introduction

The parser does not fully comply with the RFC3986. As mentioned in the [section 3.1](https://tools.ietf.org/html/rfc3986#section-3.1).

> followed by any combination of letters, digits

## Proposal

### Describe the new/upated/fixed feature

This PR fixes #13 by adding `0-9` to scheme parsing regex , so it can also parse schemes with non-leading digits.

### Backward Incompatible Changes

None I can think of.

### Targeted release version

1.2.1 ( or next release )

### PR Impact

No impact for current api

## Open issues

Fixes #13 
