### PR TITLE
Fix global \Exception namespace

### DIFF
--- a/src/UriException.php
+++ b/src/UriException.php
@@ -25,6 +25,6 @@ namespace League\Uri;
  * @author  Ignace Nyamagana Butera <nyamsprod@gmail.com>
  * @since   1.1.0
  */
-class UriException extends Exception
+class UriException extends \Exception
 {
 }


### PR DESCRIPTION
## Introduction

Usage of Exception without preceding '\\' causes 7.4 opcache preload mechanism to segfault

## Proposal

### Describe the new/updated/fixed feature

Just put a preceding '\\'

### Backward Incompatible Changes

Maybe for some people, who polluted the global namespace with their own Exception class in some sort

### Targeted release version

Any patch release will do

### PR Impact

None

## Open issues

None
